### PR TITLE
[RFC] Fix pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,5 @@ dependencies = [
 [project.scripts]
 pdr = "pdr.cli:main"
 
-
-
 [tool.setuptools]
-packages = ["cartridges", "scripts"]
+packages = ["cartridges", "examples"]


### PR DESCRIPTION
Hi folks, thanks for the recent updates! Been having a ton of fun playing around with Cartridges.

Anyways, in a fresh clone

```
>> uv venv
>> source .venv/bin/activate
>> uv sync

error: package directory 'scripts' does not exist
```

Post refactor, it looks like `scripts` moved to `examples` and this PR reflects that in `pyproject.toml`.

btw, is 

```
[project.scripts]
pdr = "pdr.cli:main"
```

Also outdated?
