### PR TITLE
Fix: small typo in readme model identifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ uv pip install -e .
 
 2. Start the server:
 ```bash
-tksrs model=Qwen3/Qwen3-4b kv_cache_num_tokens='(512 * 1024)' max_top_logprobs=20 dp_size=1
+tksrs model=Qwen/Qwen3-4b kv_cache_num_tokens='(512 * 1024)' max_top_logprobs=20 dp_size=1
 ```
 
 


### PR DESCRIPTION
In the readme instructions for setting up Tokasaurus locally, the model identifier is `Qwen3/Qwen3-4b`, but it should be `Qwen/Qwen3-4b`.